### PR TITLE
Fix python unittest github workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ jobs:
   python-unittest:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,4 +8,5 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'
+      - run: python3 -m pip install -r src/requirements.txt
       - run: python3 -m unittest

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 tornado==6.1
 pymunk==6.2.1
+pygame==2.1.2


### PR DESCRIPTION
Now the unit tests are actually being run by the github workflow.

- Add checkout action so that workflow has access to the repo contents
- Add command to pip install from requirements.txt
- Add pygame to requirements.txt

Fixes #6 