### PR TITLE
Implement switching screens based on game state

### DIFF
--- a/src/frontend/css/style.css
+++ b/src/frontend/css/style.css
@@ -14,3 +14,6 @@
   font-family:'Courier New', Courier, monospace;
   color: red;
 }
+.hidden {
+  display: none;
+}

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -14,21 +14,24 @@
 
 <body>
   <script src="js/main.js" type="module"></script>
-  <script src="js/gameSetup.js"></script>
 
   <h1>ECE 493 Capstone Project</h1>
 
-  <label for="classNameArea">Class name:</label>
-  <textarea id="classNameArea" rows="1" cols="80">
+  <div id="queueScreen">Waiting in matchmaking queue.</div>
+
+  <div id="codeInputScreen" class="hidden">
+    <label for="classNameArea">Class name:</label>
+    <textarea id="classNameArea" rows="1" cols="80">
 MyAgent
-  </textarea>
-  <textarea id="codeArea" rows="30" cols="80">
+    </textarea>
+    <textarea id="codeArea" rows="30" cols="80">
 class MyAgent(Agent):
     """Enter your code here ..."""</textarea>
-  <button type="button" id="submitButton">Submit Code</button>
+    <button type="button" id="submitButton">Submit Code</button>
+  </div>
 
   <!-- Place to print python error messages to the player. -->
-  <div id="pythonErrorsArea">
+  <div id="pythonErrorsArea" class="hidden">
   </div>
 </body>
 </html>

--- a/src/frontend/js/clienttoserverconnection.js
+++ b/src/frontend/js/clienttoserverconnection.js
@@ -24,6 +24,12 @@ export default class ClientToServerConnection {
             case Message.PYTHON_ERROR:
                 this.onPythonError(message.data);
                 break;
+            case Message.START_GAME:
+                this.onStartGame();
+                break;
+            case Message.START_SIMULATION:
+                this.onStartSimulation();
+                break;
             default:
                 console.error("ERROR: unhandled message type. Message:", message);
         }
@@ -49,5 +55,19 @@ export default class ClientToServerConnection {
      */
     onPythonError(error) {
         console.error(error);
+    }
+
+    /**
+     * Can be overwritten by another class.
+     */
+    onStartGame(error) {
+        console.log("START_GAME message received");
+    }
+
+    /**
+     * Can be overwritten by another class.
+     */
+    onStartSimulation(error) {
+        console.log("START_SIMULATION message received");
     }
 }

--- a/src/frontend/js/gameSetup.js
+++ b/src/frontend/js/gameSetup.js
@@ -20,29 +20,7 @@ const PI = 3.14,
   AGENT_GUN_X_NORM = 0.95686,
   AGENT_GUN_Y_NORM = 0.75349;
 
-//Create a Pixi Application
-const app = new Application({
-  width: 1024, // default: 800
-  height: 700, // default: 600
-  antialias: true, // default: false
-  transparent: false, // default: false
-  resolution: 1, // default: 1
-});
-
-//Add the canvas that Pixi automatically created for you to the HTML document
-document.body.appendChild(app.view);
-app.renderer.autoDensity = true;
-
-//load an image and run the `setup` function when it's done
-loader
-  .add("../assets/sample.png")
-  .add("../assets/dungeon.json")
-  .add("../assets/agentsheet.json")
-  .add("../assets/agentsheet.png")
-  .add("../assets/obstacleboxes.json")
-  .add("../assets/obstacleboxes.png")
-  .add("../assets/bulletSprite.png")
-  .load(setup);
+let app;
 
 let agentSheet,
   id,
@@ -53,6 +31,32 @@ let agentSheet,
   obstacleSSheet,
   projectileList,
   projectileSpeed;
+
+export default function initPixi() {
+  //Create a Pixi Application
+  app = new Application({
+    width: 1024, // default: 800
+    height: 700, // default: 600
+    antialias: true, // default: false
+    transparent: false, // default: false
+    resolution: 1, // default: 1
+  });
+
+  //Add the canvas that Pixi automatically created for you to the HTML document
+  document.body.appendChild(app.view);
+  app.renderer.autoDensity = true;
+
+  //load an image and run the `setup` function when it's done
+  loader
+    .add("../assets/sample.png")
+    .add("../assets/dungeon.json")
+    .add("../assets/agentsheet.json")
+    .add("../assets/agentsheet.png")
+    .add("../assets/obstacleboxes.json")
+    .add("../assets/obstacleboxes.png")
+    .add("../assets/bulletSprite.png")
+    .load(setup);
+}
 
 //This `setup` function will run when the image has loaded
 function setup() {
@@ -144,7 +148,7 @@ function setup() {
   projectileList = [];
   projectileSpeed = 5;
 
-  background = new Sprite(id["dungeon.png"]);
+  const background = new Sprite(id["dungeon.png"]);
   background.scale.set(2, 1.367);
   //   agent size and obstacle size are 50 px
 

--- a/src/frontend/js/renderer.js
+++ b/src/frontend/js/renderer.js
@@ -1,3 +1,5 @@
+import initPixi from "./gameSetup.js";
+
 /**
  * Deals with UI and rendering.
  */
@@ -7,6 +9,8 @@ export default class Renderer {
     #classNameArea;
     #submitButton;
     #pythonErrorsArea;
+    #queueScreen;
+    #codeInputScreen;
 
     constructor(clientToServerConnection) {
         this.#server = clientToServerConnection;
@@ -18,6 +22,12 @@ export default class Renderer {
 
         this.#pythonErrorsArea = document.getElementById("pythonErrorsArea");
         this.#server.onPythonError = (error) => { this.#onPythonError(error); };
+
+        this.#server.onStartGame = () => { this.#onStartGame(); };
+        this.#server.onStartSimulation = () => { this.#onStartSimulation(); };
+
+        this.#queueScreen = document.getElementById("queueScreen");
+        this.#codeInputScreen = document.getElementById("codeInputScreen");
     }
 
     #sendCodeToServer() {
@@ -28,5 +38,18 @@ export default class Renderer {
 
     #onPythonError(error) {
         this.#pythonErrorsArea.textContent = error;
+    }
+
+    #onStartGame() {
+        this.#queueScreen.classList.add("hidden");
+        this.#codeInputScreen.classList.remove("hidden");
+        this.#pythonErrorsArea.classList.remove("hidden");
+    }
+
+    #onStartSimulation() {
+        this.#codeInputScreen.classList.add("hidden");
+
+        // Initialize the Pixi canvas
+        initPixi();
     }
 }


### PR DESCRIPTION
#9 should be merged first

This PR implements hiding and revealing of UI elements based on the game state.
- When a player first loads the page, it simply shows a message saying they are in the matchmaking queue.
- Once two players have loaded the page, a game is started and the code input screen is shown to both players.
- Once both players submit valid code, the map is rendered and code input is hidden.

To hide HTML elements, I created a css class called `hidden`.

I moved all the pixi initialization into a function called `initPixi` so that the map isn't rendered immediately but can be rendered when the simulation starts.