### PR TITLE
Send message to client when projectile or agent is destroyed

### DIFF
--- a/src/frontend/js/clienttoserverconnection.js
+++ b/src/frontend/js/clienttoserverconnection.js
@@ -37,6 +37,10 @@ export default class ClientToServerConnection {
             case Message.PROJECTILE_STATES:
                 this.onReceiveProjectileStates(message.data);
                 break;
+            case Message.DESTROY:
+                console.log(message);
+                this.onReceiveDestroy(message.data.id, message.data.type);
+                break;
             default:
                 console.error("ERROR: unhandled message type. Message:", message);
         }
@@ -103,5 +107,9 @@ export default class ClientToServerConnection {
 
     onReceiveProjectileStates(projectile_states) {
         console.log(projectile_states);
+    }
+
+    onReceiveDestroy(id, type) {
+        console.log(`DESTROY id: ${id}, type: ${type}`);
     }
 }

--- a/src/frontend/js/message.js
+++ b/src/frontend/js/message.js
@@ -9,6 +9,7 @@ export default class Message {
     static PYTHON_ERROR = "python_error";
     static START_SIMULATION = "start_simulation";
     static PROJECTILE_STATES = "projectile_states";
+    static DESTROY = "destroy";
     static AGENT_STATES = "agent_states";
 
     constructor(type, data) {

--- a/src/game.py
+++ b/src/game.py
@@ -112,6 +112,8 @@ class Game():
                     agent.on_damage_taken()
                 # remove the projectile
                 self.physics.remove_object(projectile.id)
+                for agent in self.agents:
+                    agent[0].send_destroy_message(projectile.id, "projectile")
             else:
                 # handle projectile-obstacle collision
                 if isinstance(object_state_1, ProjectileState):
@@ -120,6 +122,8 @@ class Game():
                     projectile = object_state_1
                 # remove the projectile
                 self.physics.remove_object(projectile.id)
+                for agent in self.agents:
+                    agent[0].send_destroy_message(projectile.id, "projectile")
         else:
             # handle agent-obstacle collision
             if isinstance(object_state_1, AgentState):

--- a/src/game.py
+++ b/src/game.py
@@ -83,8 +83,9 @@ class Game():
             # TODO do we need to handle both agents reaching 0 health in the
             # same tick?
             game_ended = True
+            destroyed_id = agent[1].agent_state.id
             for agent in self.agents:
-                agent[0].send_destroy_message(agent[1].agent_state.id, "agent")
+                agent[0].send_destroy_message(destroyed_id, "agent")
 
         # send updates to clients
         for agent in self.agents:

--- a/src/message.py
+++ b/src/message.py
@@ -24,6 +24,13 @@ class Message():
     # data: a list of ProjectileStates
     PROJECTILE_STATES = "projectile_states"
 
+    # Send client the id of an object that was destroyed
+    # data: {
+    #     id: id of destroyed object
+    #     type: type of destroyed object. Possible values: "agent", "projectile"
+    # }
+    DESTROY = "destroy"
+
     # Tell client that the simulation is starting. (Code submission is done)
     # data: None
     START_SIMULATION = "start_simulation"

--- a/src/message.py
+++ b/src/message.py
@@ -65,6 +65,10 @@ class Message():
         if isinstance(self.data, list):
             # if data is a list convert it to a json array
             data = [object.to_json_dict() for object in self.data]
+        elif isinstance(self.data, dict):
+            # a dict will be converted by json.dumps. don't convert it to a
+            # string.
+            data = self.data
         elif self.data is not None:
             # otherwise if data is not none convert it to a string
             data = self.data.__str__()

--- a/src/physics_engine.py
+++ b/src/physics_engine.py
@@ -48,17 +48,13 @@ class PhysicsEngine:
             False if the collision should be ignored.
         """
         # stop the objects from moving
-        print("Colliding...")
         arbiter.shapes[0].body.velocity = (0, 0)
         arbiter.shapes[1].body.velocity = (0, 0)
-        # print(arbiter.shapes[0].body.position)
-        # print(arbiter.shapes[1].body.position)
-        # print(arbiter.contact_point_set)
-        print("Collision!")
         object_id_1 = self._get_body_id(arbiter.shapes[0].body)
         object_id_2 = self._get_body_id(arbiter.shapes[1].body)
         object_state_1 = self._get_object_state_from_id(object_id_1)
         object_state_2 = self._get_object_state_from_id(object_id_2)
+        print(f"Collision between object ids: {object_id_1} and {object_id_2}")
         # call the optional callback function
         if "collision_callback" in data:
             data["collision_callback"](object_state_1, object_state_2, arbiter.contact_point_set.points[0].point_a)

--- a/src/server.py
+++ b/src/server.py
@@ -92,6 +92,13 @@ class ServerToClientConnection(tornado.websocket.WebSocketHandler):
         message = Message(Message.PROJECTILE_STATES, projectile_states)
         self.write_message(message.to_json())
 
+    def send_destroy_message(self, object_id, object_type):
+        message = Message(Message.DESTROY, {
+            "id": object_id,
+            "type": object_type
+        })
+        self.write_message(message.to_json())
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -214,6 +214,38 @@ class MyAgent(Agent):
             self.game.tick()
         self.assertGreaterEqual(agent.agent_state.position.y, 0)
 
+    def test_destroy_projectile_message(self):
+        attacker = Agent(self.game.gen_id(), self.game)
+        attackee = Agent(self.game.gen_id(), self.game)
+        self.game.agents = [[MagicMock(), attacker], [MagicMock(), attackee]]
+
+        self.game.prepare_to_start_simulation()
+
+        attacker.attack_ranged(0)
+
+        for _ in range(TICKS_PER_SECOND * 10):
+            self.game.tick()
+
+        for agent in self.game.agents:
+            agent[0].send_destroy_message.assert_called_with(2, "projectile")
+
+    def test_destroy_agent_message(self):
+        attacker = Agent(self.game.gen_id(), self.game)
+        attackee = Agent(self.game.gen_id(), self.game)
+        self.game.agents = [[MagicMock(), attacker], [MagicMock(), attackee]]
+
+        self.game.prepare_to_start_simulation()
+
+        # Perform enough attacks to eliminate attackee
+        for _ in range(math.ceil(Agent.MAX_HEALTH / Agent.DAMAGE_AMOUNT)):
+            attacker.attack_ranged(0)
+
+            for _ in range(TICKS_PER_SECOND * 10):
+                self.game.tick()
+
+        for agent in self.game.agents:
+            agent[0].send_destroy_message.assert_called_with(1, "agent")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #16

I created a new message type (`DESTROY`) that contains the id and the type of object that was destroyed.

I wrote unit tests for this.

This can also be verified in the client by entering the following player code for the first agent:
```python
class MyAgent(Agent):
    """Enter your code here ..."""
    x = 20
    def run(self):
        self.attack_ranged(0)
```

Open the console and check for messages such as `DESTROY id: 11, type: projectile`. (You can use the filter to only show messages that start with "DESTROY").
There should also be one destroy message that reads: `DESTROY id: 1, type: agent` when the second agent's health reaches zero.