### PR TITLE
Send results

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -39,6 +39,8 @@ class Agent:
         # Dict to map any objects that are colliding with this agent to the point at which they have collided.
         self.collisions = {}
 
+        self.survival_time = None
+
     def run(self):
         """This function will be called repeatedly in the main game loop.
 

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -30,6 +30,11 @@ class MyAgent(Agent):
     <button type="button" id="submitButton">Submit Code</button>
   </div>
 
+  <div id="resultsScreen" class="hidden">
+    <p id="declareWinnerArea"></p>
+    <p id="individualResultsArea"></p>
+  </div>
+
   <!-- Place to print python error messages to the player. -->
   <div id="pythonErrorsArea" class="hidden">
   </div>

--- a/src/frontend/js/clienttoserverconnection.js
+++ b/src/frontend/js/clienttoserverconnection.js
@@ -41,6 +41,10 @@ export default class ClientToServerConnection {
                 console.log(message);
                 this.onReceiveDestroy(message.data.id, message.data.type);
                 break;
+            case Message.RESULTS:
+                console.log(message.data);
+                this.onReceiveResults(message.data["winner"], message.data["tie"], message.data["players"]);
+                break;
             default:
                 console.error("ERROR: unhandled message type. Message:", message);
         }
@@ -111,5 +115,9 @@ export default class ClientToServerConnection {
 
     onReceiveDestroy(id, type) {
         console.log(`DESTROY id: ${id}, type: ${type}`);
+    }
+
+    onReceiveResults(winner, tie, player_results) {
+        console.log(player_results);
     }
 }

--- a/src/frontend/js/message.js
+++ b/src/frontend/js/message.js
@@ -11,6 +11,7 @@ export default class Message {
     static PROJECTILE_STATES = "projectile_states";
     static DESTROY = "destroy";
     static AGENT_STATES = "agent_states";
+    static RESULTS = "results";
 
     constructor(type, data) {
         this.type = type;

--- a/src/frontend/js/renderer.js
+++ b/src/frontend/js/renderer.js
@@ -11,6 +11,9 @@ export default class Renderer {
     #pythonErrorsArea;
     #queueScreen;
     #codeInputScreen;
+    #resultsScreen;
+    #declareWinnerArea;
+    #individualResultsArea;
 
     constructor(clientToServerConnection) {
         this.#server = clientToServerConnection;
@@ -25,9 +28,14 @@ export default class Renderer {
 
         this.#server.onStartGame = () => { this.#onStartGame(); };
         this.#server.onStartSimulation = () => { this.#onStartSimulation(); };
+        this.#server.onReceiveResults = (winner, tie, player_results) => { this.#onReceiveResults(winner, tie, player_results); };
 
         this.#queueScreen = document.getElementById("queueScreen");
         this.#codeInputScreen = document.getElementById("codeInputScreen");
+
+        this.#resultsScreen = document.getElementById("resultsScreen");
+        this.#declareWinnerArea = document.getElementById("declareWinnerArea");
+        this.#individualResultsArea = document.getElementById("individualResultsArea");
     }
 
     #sendCodeToServer() {
@@ -51,5 +59,31 @@ export default class Renderer {
 
         // Initialize the Pixi canvas
         initPixi();
+    }
+
+    #onReceiveResults(winner, tie, player_results) {
+        console.log("showing results!");
+        document.getElementsByTagName("canvas")[0].classList.add("hidden");
+        this.#resultsScreen.classList.remove("hidden");
+        if (tie) {
+            this.#declareWinnerArea.innerHTML = "It's a Tie!";
+        }
+        else if (winner) {
+            this.#declareWinnerArea.innerHTML = "You Win, Congratulations!";
+        }
+        else {
+            this.#declareWinnerArea.innerHTML = "You Lost, Better Luck Next Time!";
+        }
+        var results_text = ""
+        player_results.forEach(function(result) {
+            results_text += result["class_name"];
+            if (result["survival_time"] == null) {
+                results_text += " survived the entire game!" + "<br/>";
+            }
+            else {
+                results_text += " survived for " + result["survival_time"].toString() + " seconds<br/>";
+            }
+        });
+        this.#individualResultsArea.innerHTML = results_text;
     }
 }

--- a/src/message.py
+++ b/src/message.py
@@ -47,6 +47,17 @@ class Message():
     # data: error message as string
     PYTHON_ERROR = "python_error"
 
+    # Tells the client that the game has ended and provides the results to display
+    # data: {
+    #     winner: bool indicating whether the client receiving this message won
+    #     tie: bool indicating whether the game ended in a tie
+    #     players: {
+    #        class_name: name of the class submitted by the player
+    #        survival_time: float survival time in seconds or None if the player survived the entire game
+    #     }
+    # }
+    RESULTS = "results"
+
     def __init__(self, _type, data):
         """Constructor
 

--- a/src/server.py
+++ b/src/server.py
@@ -78,6 +78,23 @@ class ServerToClientConnection(tornado.websocket.WebSocketHandler):
         )
         self.send_message(message)
 
+    def send_results(self, winner, tie, agents):
+        message = Message(Message.RESULTS, {
+            "winner": winner,
+            "tie": tie,
+            "players": [
+                {
+                    "class_name": type(agents[0][1]).__name__,
+                    "survival_time": agents[0][1].survival_time
+                },
+                {
+                    "class_name": type(agents[1][1]).__name__,
+                    "survival_time": agents[1][1].survival_time
+                }
+            ]
+        })
+        self.send_message(message)
+
     def handle_player_code_message(self, message):
         code = message.data["code"]
         class_name = message.data["class_name"]

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 import math
+from time import time
 
 from src.game import *
 from src.vector2 import Vector2
@@ -235,6 +236,8 @@ class MyAgent(Agent):
         self.game.agents = [[MagicMock(), attacker], [MagicMock(), attackee]]
 
         self.game.prepare_to_start_simulation()
+        
+        self.game.game_start_time = time()
 
         # Perform enough attacks to eliminate attackee
         for _ in range(math.ceil(Agent.MAX_HEALTH / Agent.DAMAGE_AMOUNT)):


### PR DESCRIPTION
Added a results message type.

Server sends results to each client after the game ends. Each client receives the survival times of each player and a boolean to tell them if they won or lost.

Clients hide the game and show the results after receiving a results message.

I used the player's class names to identify the agents in the results screen. The results don't show a survival time for agent's that lasted the entire game. The results screen also indicates if the game ended in a tie. I can definitely change how the results are displayed if anyone has feedback.

I didn't add any unit tests for this. I think end to end testing is more applicable here. You can submit this code for the first agent to test the results screen:

class MyAgent(Agent):
    """Enter your code here ..."""
    x = 20
    def run(self):
        self.attack_ranged(0)