### PR TITLE
Use relative coordinates when contructing obstacle segments

### DIFF
--- a/src/physics_engine.py
+++ b/src/physics_engine.py
@@ -177,10 +177,10 @@ class PhysicsEngine:
         self.space.add(obstacle_body)
 
         # TODO: make the obstacle shapes match the obstacle sprites
-        lower_left_point = (obstacle.position.x - obstacle.width/2, obstacle.position.y - obstacle.height/2)
-        upper_left_point = (obstacle.position.x - obstacle.width/2, obstacle.position.y + obstacle.height/2)
-        upper_right_point = (obstacle.position.x + obstacle.width/2, obstacle.position.y + obstacle.height/2)
-        lower_right_point = (obstacle.position.x + obstacle.width/2, obstacle.position.y - obstacle.height/2)
+        lower_left_point = (-obstacle.width/2, -obstacle.height/2)
+        upper_left_point = (-obstacle.width/2, +obstacle.height/2)
+        upper_right_point = (+obstacle.width/2, +obstacle.height/2)
+        lower_right_point = (+obstacle.width/2, -obstacle.height/2)
         start_points = [lower_left_point, upper_left_point, upper_right_point, lower_right_point]
         end_points = [upper_left_point, upper_right_point, lower_right_point, lower_left_point]
         

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -59,7 +59,7 @@ class MyAgent(Agent):
         agent.agent_state.velocity = Vector2(100, 0)
         self.game.physics.add_agent(agent.agent_state)
         self.game.physics.add_obstacle(obstacle)
-        self.game.physics.step(2)
+        self.game.physics.step(1)
         assert(agent.on_obstacle_hit.called)
 
     def test_damage_taken_callback(self):
@@ -85,7 +85,7 @@ class MyAgent(Agent):
         agent.agent_state.velocity = Vector2(100, 0)
         self.game.physics.add_agent(agent.agent_state)
         self.game.physics.add_obstacle(obstacle)
-        for _ in range(70):
+        for _ in range(10):
             self.game.tick()
         collision_callback.assert_not_called()
         agent.on_obstacle_scanned.assert_called_with(obstacle)

--- a/test/test_physics.py
+++ b/test/test_physics.py
@@ -48,7 +48,7 @@ class TestPhysicsEngine(unittest.TestCase):
         obstacle = Obstacle(2, Vector2(100, 70), 30, 30)
         self.pe.add_agent(agent_state)
         self.pe.add_obstacle(obstacle)
-        self.pe.step(2)
+        self.pe.step(1)
         assert(self.callback.called)
         assert(len(self.pe.space.bodies) == 2 + self.num_boundaries)
 


### PR DESCRIPTION
Fixes #41

Pymunk shapes expect coordinates relative to the position of the body, not the entire space: http://www.pymunk.org/en/latest/pymunk.html#pymunk.Poly