### PR TITLE
Implement end-to-end test for completed game

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -30,10 +30,10 @@ class Agent:
     SHIELD_COOLDOWN_MAX = 20
     ATTACK_COOLDOWN_MAX = 0.5
     TIMER_DECREMENT = 1 / TICKS_PER_SECOND
-    SCAN_DISTANCE = 50
-    MAX_SPEED = 50 # in units of pixels per second
+    SCAN_DISTANCE = 200
+    MAX_SPEED = 200 # in units of pixels per second
     MAX_SPEED_DURING_ATTACK = MAX_SPEED * 0.5
-    PROJECTILE_SPEED = 200
+    PROJECTILE_SPEED = 1000
 
     def __init__(self, id, game):
         self.agent_state = AgentState(

--- a/src/game.py
+++ b/src/game.py
@@ -22,6 +22,7 @@ from src.projectile_state import ProjectileState
 from src.agent_state import AgentState
 from src.obstacle import Obstacle
 from src.vector2 import Vector2
+import os
 from time import time
 import sys
 
@@ -52,6 +53,11 @@ class Game():
         self.physics = PhysicsEngine()
         self.physics.add_on_collision_callback(self.collision_callback)
         self.physics.add_on_separate_callback(self.separate_callback)
+        self.debug_render = False
+        if "GUI" in os.environ and os.environ['GUI'] != "":
+            self.debug_render = True
+        if self.debug_render:
+            self.physics.init_renderer()
 
         for client in self.clients:
             def callback(client, code, class_name):
@@ -134,6 +140,9 @@ class Game():
             destroyed_id = agent[1].agent_state.id
             for agent in self.agents:
                 agent[0].send_destroy_message(destroyed_id, "agent")
+
+        if self.debug_render:
+            self.physics.render_tick()
 
         # send updates to clients
         for agent in self.agents:

--- a/src/physics_engine.py
+++ b/src/physics_engine.py
@@ -116,6 +116,21 @@ class PhysicsEngine:
         """
         self.collision_handler.data["separate_callback"] = callback
 
+    def init_renderer(self):
+        """Initialize the pygame renderer. This is for debug purposes only"""
+        # use pygame for testing
+        pygame.init()
+        size = PhysicsEngine.SPACE_WIDTH, PhysicsEngine.SPACE_HEIGHT
+        self.screen = pygame.display.set_mode(size)
+        self.draw_options = pymunk.pygame_util.DrawOptions(self.screen)
+
+    def render_tick(self):
+        """Update the pygame render. This should be called in the game loop."""
+        GRAY = (220, 220, 220)
+        self.screen.fill(GRAY)
+        self.space.debug_draw(self.draw_options)
+        pygame.display.update()
+
     def run_render_test(self):
         """
         Renders the current space using pygame. This is for debug purposes only.
@@ -133,7 +148,7 @@ class PhysicsEngine:
                 if event.type == pygame.QUIT:
                     running = False
 
-            screen.fill(GRAY)
+            self.screen.fill(GRAY)
             self.space.debug_draw(draw_options)
             pygame.display.update()
 

--- a/test/agent_code/agent1.py
+++ b/test/agent_code/agent1.py
@@ -1,13 +1,27 @@
 import math
+
 class Agent1(Agent):
-    """Enter your code here ..."""
-    angle = 0
-    movement = 50
+    angle = 20
+    movement = 250
+    hit_flag = False
+    x = 20
+
     def run(self):
-        self.set_movement_speed(Agent1.movement)
-        self.set_movement_direction(Agent1.angle)
+        if Agent1.hit_flag:
+            self.set_movement_direction(Agent1.angle - 90)
+            self.set_movement_speed(Agent1.movement)
+            Agent1.x -= 1
+        if Agent1.x <= 0:
+            Agent1.hit_flag = False
+            Agent1.x = 20
+        else:
+            self.set_movement_speed(Agent1.movement)
+            self.set_movement_direction(Agent1.angle)
+
     def on_obstacle_hit(self):
         Agent1.angle += 90
+        Agent1.hit_flag = True
+
     def on_enemy_scanned(self, enemy_position):
         # shoot towards enemy when they are near
         distance = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
@@ -15,6 +29,7 @@ class Agent1(Agent):
         self.attack_ranged(angle)
         # pursue the enemy!
         Agent1.angle = angle
+
     def on_damage_taken(self):
         # activate shield and change direction when hit
         self.activate_shield()

--- a/test/agent_code/agent1.py
+++ b/test/agent_code/agent1.py
@@ -2,30 +2,21 @@ import math
 
 class Agent1(Agent):
     angle = 20
-    movement = 250
-    hit_flag = False
-    x = 20
+    speed = 250
 
     def run(self):
-        if Agent1.hit_flag:
-            self.set_movement_direction(Agent1.angle - 90)
-            self.set_movement_speed(Agent1.movement)
-            Agent1.x -= 1
-        if Agent1.x <= 0:
-            Agent1.hit_flag = False
-            Agent1.x = 20
-        else:
-            self.set_movement_speed(Agent1.movement)
-            self.set_movement_direction(Agent1.angle)
+        self.set_movement_speed(Agent1.speed)
+        self.set_movement_direction(Agent1.angle)
 
     def on_obstacle_hit(self):
-        Agent1.angle += 90
-        Agent1.hit_flag = True
+        # Change direction when an obstacle is hit
+        Agent1.angle -= 180
+        Agent1.angle %= 360
 
     def on_enemy_scanned(self, enemy_position):
         # shoot towards enemy when they are near
         distance = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
-        angle = math.atan2(distance[1], distance[0])
+        angle = math.degrees(math.atan2(distance[1], distance[0]))
         self.attack_ranged(angle)
         # pursue the enemy!
         Agent1.angle = angle

--- a/test/agent_code/agent1.py
+++ b/test/agent_code/agent1.py
@@ -1,0 +1,21 @@
+import math
+class Agent1(Agent):
+    """Enter your code here ..."""
+    angle = 0
+    movement = 50
+    def run(self):
+        self.set_movement_speed(Agent1.movement)
+        self.set_movement_direction(Agent1.angle)
+    def on_obstacle_hit(self):
+        Agent1.angle += 90
+    def on_enemy_scanned(self, enemy_position):
+        # shoot towards enemy when they are near
+        distance = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
+        angle = math.atan2(distance[1], distance[0])
+        self.attack_ranged(angle)
+        # pursue the enemy!
+        Agent1.angle = angle
+    def on_damage_taken(self):
+        # activate shield and change direction when hit
+        self.activate_shield()
+        Agent1.angle -= 45

--- a/test/agent_code/agent2.py
+++ b/test/agent_code/agent2.py
@@ -1,0 +1,29 @@
+import math
+
+class Agent2(Agent):
+    angle = 20
+    speed = 250
+
+    def run(self):
+        self.set_movement_speed(Agent2.speed)
+        self.set_movement_direction(Agent2.angle)
+
+    def on_obstacle_hit(self):
+        # Change direction when an obstacle is hit
+        Agent2.angle -= 180
+        Agent2.angle %= 360
+
+    def on_enemy_scanned(self, enemy_position):
+        self.activate_shield()
+        # shoot towards enemy when they are near
+        distance = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
+        angle = math.degrees(math.atan2(distance[1], distance[0]))
+        self.attack_ranged(angle)
+        # run away from the enemy!
+        Agent2.angle = 180 - angle
+        Agent2.angle %= 180
+
+    def on_damage_taken(self):
+        # activate shield and change direction when hit
+        self.activate_shield()
+        Agent2.angle -= 45

--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -101,7 +101,26 @@ improper syntax!!!
         wait.until(EC.text_to_be_present_in_element((By.ID, "pythonErrorsArea"), "IndentationError"))
 
     def test_completed_game(self):
-        pass
+        """This test can be run in headed mode with the following command:
+        GUI=1 python -m unittest test.test_frontend.TestFrontend.test_completed_game
+        """
+        agent_code = self.get_code_from_file("test/agent_code/agent1.py")
+        for driver in self.drivers:
+            code_area = WebDriverWait(driver, timeout=TestFrontend.TIMEOUT).until(lambda d: d.find_element(By.ID, "codeArea"))
+            code_area.clear()
+            code_area.send_keys(agent_code)
+
+            class_name_area = driver.find_element(By.ID, "classNameArea")
+            class_name_area.clear()
+            class_name_area.send_keys("Agent1")
+
+        for driver in self.drivers:
+            submit_button = driver.find_element(By.ID, "submitButton")
+            submit_button.click()
+
+        for driver in self.drivers:
+            wait = WebDriverWait(driver, timeout=60)
+            wait.until(EC.text_to_be_present_in_element((By.ID, "declareWinnerArea"), "You!"))
 
 
 if __name__ == '__main__':

--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -104,23 +104,32 @@ improper syntax!!!
         """This test can be run in headed mode with the following command:
         GUI=1 python -m unittest test.test_frontend.TestFrontend.test_completed_game
         """
-        agent_code = self.get_code_from_file("test/agent_code/agent1.py")
-        for driver in self.drivers:
-            code_area = WebDriverWait(driver, timeout=TestFrontend.TIMEOUT).until(lambda d: d.find_element(By.ID, "codeArea"))
+        agent_code = [
+            self.get_code_from_file("test/agent_code/agent1.py"),
+            self.get_code_from_file("test/agent_code/agent2.py"),
+        ]
+        agent_names = [
+            "Agent1",
+            "Agent2",
+        ]
+        for i in range(len(self.drivers)):
+            code_area = WebDriverWait(self.drivers[i], timeout=TestFrontend.TIMEOUT).until(lambda d: d.find_element(By.ID, "codeArea"))
             code_area.clear()
-            code_area.send_keys(agent_code)
+            code_area.send_keys(agent_code[i])
 
-            class_name_area = driver.find_element(By.ID, "classNameArea")
+            class_name_area = self.drivers[i].find_element(By.ID, "classNameArea")
             class_name_area.clear()
-            class_name_area.send_keys("Agent1")
+            class_name_area.send_keys(agent_names[i])
 
         for driver in self.drivers:
             submit_button = driver.find_element(By.ID, "submitButton")
             submit_button.click()
 
-        for driver in self.drivers:
-            wait = WebDriverWait(driver, timeout=60)
-            wait.until(EC.text_to_be_present_in_element((By.ID, "declareWinnerArea"), "You!"))
+        wait = WebDriverWait(self.drivers[0], timeout=60)
+        wait.until(EC.text_to_be_present_in_element((By.ID, "declareWinnerArea"), "You Lost, Better Luck Next Time!"))
+
+        wait = WebDriverWait(self.drivers[1], timeout=60)
+        wait.until(EC.text_to_be_present_in_element((By.ID, "declareWinnerArea"), "You Win, Congratulations!"))
 
 
 if __name__ == '__main__':

--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -52,6 +52,11 @@ class TestFrontend(unittest.TestCase):
         for driver in self.drivers:
             driver.quit()
 
+    def get_code_from_file(self, filename):
+        with open(filename) as f:
+            contents = f.read()
+        return contents
+
     def test_exception_during_game(self):
         code_area = WebDriverWait(self.drivers[0], timeout=TestFrontend.TIMEOUT).until(lambda d: d.find_element(By.ID, "codeArea"))
         code_area.clear()

--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -39,7 +39,8 @@ class TestFrontend(unittest.TestCase):
         # Open 2 browsers
         options = Options()
         # Must run headless for chromedriver to work in github actions
-        options.headless = True
+        if not "GUI" in os.environ or os.environ['GUI'] == "":
+            options.headless = True
         self.drivers = []
         for _ in range(2):
             self.drivers.append(webdriver.Chrome(service=Service(TestFrontend.driver_manager), options=options))

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -78,11 +78,12 @@ class MyAgent(Agent):
         collision_callback = MagicMock()
         self.game.physics.add_on_collision_callback(collision_callback)
         agent = Agent(self.game.gen_id(), self.game)
-        obstacle = Obstacle(self.game.gen_id(), Vector2(200, 70), 30, 30)
+        obstacle = Obstacle(self.game.gen_id(), Vector2(500, 300), 30, 30)
         agent.on_obstacle_scanned = MagicMock()
         self.game.agents = [[MagicMock(), agent]]
-        agent._set_position(Vector2(100, 100))
-        agent.agent_state.velocity = Vector2(40, 0)
+        # In one second, the agent, should move halfway into the scan radius
+        agent._set_position(Vector2(500 - Agent.SCAN_DISTANCE - 30, 300))
+        agent.agent_state.velocity = Vector2(Agent.SCAN_DISTANCE / 2, 0)
         self.game.physics.add_agent(agent.agent_state)
         self.game.physics.add_obstacle(obstacle)
         for _ in range(TICKS_PER_SECOND):


### PR DESCRIPTION
This doesn't close #23. There is a bit more tweaking to do. However, I think this is a good start so I'm opening this PR.

This test runs 2 different agents: Agent1 and Agent2. Agent2 should win the game.

In order to make gameplay faster/better, I tweaked some constants like agent and projectile speed and scan distance.

I also added an environment variable `GUI`. When `GUI` is set to a non-empty string, the server will run the pygame renderer and the tests will run chromium in headed mode. This is useful so you can see what's happening on both the frontend and backend during tests.

To run the test, use this command:
```bash
GUI=1 python -m unittest test.test_frontend.TestFrontend.test_completed_game
```

We still need to add more API methods to the test to make sure we cover all of them.

We also might want to add a test case where the game results in a tie. This can be done by running Agent1 against itself.