### PR TITLE
Randomize test agent movement

### DIFF
--- a/src/physics_engine.py
+++ b/src/physics_engine.py
@@ -240,9 +240,12 @@ class PhysicsEngine:
         circle = pymunk.Circle(projectile_body, radius=5)
         circle.elasticity = 0
         circle.collision_type = PhysicsEngine.COLLISION_TYPE_1
-        # Ignore collisions between an agent and its own projectile
         circle.filter = pymunk.ShapeFilter(
-            group=self._id_to_collision_group(projectile_state.attackerId)
+            # Ignore collisions between an agent and its own projectile
+            group=self._id_to_collision_group(projectile_state.attackerId),
+            categories=0b1,
+            # Ignore collisions between any 2 projectiles
+            mask=pymunk.ShapeFilter.ALL_MASKS() ^ 0b1
         )
 
         if projectile_state.id in self.bodies:

--- a/test/agent_code/agent1.py
+++ b/test/agent_code/agent1.py
@@ -15,11 +15,16 @@ class Agent1(Agent):
 
     def on_enemy_scanned(self, enemy_position):
         # shoot towards enemy when they are near
-        distance = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
-        angle = math.degrees(math.atan2(distance[1], distance[0]))
+        rel_position = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
+        angle = math.degrees(math.atan2(rel_position[1], rel_position[0]))
         self.attack_ranged(angle)
         # pursue the enemy!
         Agent1.angle = angle
+        distance = math.sqrt(rel_position[0] ** 2 + rel_position[1] ** 2)
+        if distance < 200:
+            # avoid getting too close
+            Agent1.angle -= 180
+            Agent1.angle %= 360
 
     def on_damage_taken(self):
         # activate shield and change direction when hit

--- a/test/agent_code/agent2.py
+++ b/test/agent_code/agent2.py
@@ -1,6 +1,9 @@
 import math
 import random
 
+# Make random number generation deterministic for testing and demo purposes
+random.seed(256)
+
 class Agent2(Agent):
     angle = 20
     speed = 250

--- a/test/agent_code/agent2.py
+++ b/test/agent_code/agent2.py
@@ -11,7 +11,8 @@ class Agent2(Agent):
     def run(self):
         Agent2.random_movement_timer -= 1
         if Agent2.random_movement_timer <= 0:
-            self.randomize_movement()
+            self.randomize_angle()
+            self.set_movement_direction(Agent2.angle)
             Agent2.random_movement_timer = 30 * 2
             Agent2.random_cooldown_timer = 30
         if Agent2.random_cooldown_timer > 0:
@@ -21,9 +22,8 @@ class Agent2(Agent):
         if Agent2.random_cooldown_timer <= 0:
             self.set_movement_direction(Agent2.angle)
 
-    def randomize_movement(self):
+    def randomize_angle(self):
         Agent2.angle = random.random() * 360
-        self.set_movement_direction(Agent2.angle)
 
     def on_obstacle_hit(self):
         # Change direction when an obstacle is hit
@@ -33,8 +33,8 @@ class Agent2(Agent):
     def on_enemy_scanned(self, enemy_position):
         self.activate_shield()
         # shoot towards enemy when they are near
-        distance = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
-        angle = math.degrees(math.atan2(distance[1], distance[0]))
+        rel_position = (enemy_position.x - self.get_position().x, enemy_position.y - self.get_position().y)
+        angle = math.degrees(math.atan2(rel_position[1], rel_position[0]))
         self.attack_ranged(angle)
         # run away from the enemy!
         Agent2.angle = 180 - angle

--- a/test/agent_code/agent2.py
+++ b/test/agent_code/agent2.py
@@ -1,11 +1,28 @@
 import math
+import random
 
 class Agent2(Agent):
     angle = 20
     speed = 250
 
+    random_movement_timer = 30 * 2
+    random_cooldown_timer = 0
+
     def run(self):
+        Agent2.random_movement_timer -= 1
+        if Agent2.random_movement_timer <= 0:
+            self.randomize_movement()
+            Agent2.random_movement_timer = 30 * 2
+            Agent2.random_cooldown_timer = 30
+        if Agent2.random_cooldown_timer > 0:
+            Agent2.random_cooldown_timer -= 1
+
         self.set_movement_speed(Agent2.speed)
+        if Agent2.random_cooldown_timer <= 0:
+            self.set_movement_direction(Agent2.angle)
+
+    def randomize_movement(self):
+        Agent2.angle = random.random() * 360
         self.set_movement_direction(Agent2.angle)
 
     def on_obstacle_hit(self):

--- a/test/test_frontend.py
+++ b/test/test_frontend.py
@@ -125,10 +125,10 @@ improper syntax!!!
             submit_button = driver.find_element(By.ID, "submitButton")
             submit_button.click()
 
-        wait = WebDriverWait(self.drivers[0], timeout=60)
+        wait = WebDriverWait(self.drivers[0], timeout=60 * 5)
         wait.until(EC.text_to_be_present_in_element((By.ID, "declareWinnerArea"), "You Lost, Better Luck Next Time!"))
 
-        wait = WebDriverWait(self.drivers[1], timeout=60)
+        wait = WebDriverWait(self.drivers[1], timeout=60 * 5)
         wait.until(EC.text_to_be_present_in_element((By.ID, "declareWinnerArea"), "You Win, Congratulations!"))
 
 


### PR DESCRIPTION
This makes Agent2 pick a random direction periodically. I also made it so that Agent1 maintains distance from Agent2 so that they don't get stuck together.

Sometimes the agents seem to "vibrate" back and forth really fast. I think this is because they are alternating between moving towards and away from the enemy or wall. This isn't really a bug, it just looks kinda weird for the demo. If we want to fix this we could add a cooldown for setting the direction of the agent.